### PR TITLE
Getting labrepl back in working order, and using an up-to-date Compojure

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,6 +14,6 @@
                  [jline "0.9.94"]
                  [mycroft "0.0.2"]
                  [circumspec "0.0.13"]]
-  :dev-dependencies [[autodoc "0.7.0"]
+  :dev-dependencies [[autodoc "0.7.0" :exclusions [org.clojure/clojure-contrib]]
                      [swank-clojure "1.3.0-SNAPSHOT"]]
   :repositories {"clojure-releases" "http://build.clojure.org/releases"})

--- a/project.clj
+++ b/project.clj
@@ -2,9 +2,9 @@
   :description "Clojure exercises, with integrated repl and webapp"
   :dependencies [[org.clojure/clojure "1.2.0"]
                  [org.clojure/clojure-contrib "1.2.0"]
-                 [compojure "0.5.1"]
+                 [compojure "0.6.3"]
                  [ring/ring-jetty-adapter "0.3.0"]
-                 [hiccup "0.3.0"]
+                 [hiccup "0.3.4"]
                  [postgresql "8.4-701.jdbc4"]
                  [log4j "1.2.16"]
                  [incanter "1.2.3"]

--- a/project.clj
+++ b/project.clj
@@ -14,6 +14,5 @@
                  [jline "0.9.94"]
                  [mycroft "0.0.2"]
                  [circumspec "0.0.13"]]
-  :dev-dependencies [[autodoc "0.7.0" :exclusions [org.clojure/clojure-contrib]]
-                     [swank-clojure "1.3.0-SNAPSHOT"]]
+  :dev-dependencies [[swank-clojure "1.3.0-SNAPSHOT"]]
   :repositories {"clojure-releases" "http://build.clojure.org/releases"})

--- a/src/labrepl.clj
+++ b/src/labrepl.clj
@@ -33,11 +33,11 @@
            (fn [lab] [:li (lab/make-url lab)])
            (lab/all))])))
   (GET "/labs/:name"
-       request
+       [name]
        (html
         (lab/layout
-         [:h2 ((request :params) "name")]
-         (lab/instructions ((request :params) "name"))))))
+         [:h2 name]
+         (lab/instructions name)))))
 
 (defroutes static-routes
   (route/files "/")

--- a/src/labs/mini_browser.clj
+++ b/src/labs/mini_browser.clj
@@ -22,7 +22,7 @@
   [[:h3 "Layout"]
    [:p "Clojure data can easily be viewed as isomorphic to HTML. A Clojure vector that begins with a keyword is an HTML element, a Clojure map is HTML attributes, and strings are strings. Compojure exposes the isomorphism through the " (c html) " function, which we will use to build a mockup of the mini-browser."]
    [:ol
-    [:li "From a REPL, use the compojure namespace."]
+    [:li "From a REPL, use the " (c hiccup.core) " namespace."]
     [:li "Create a simple paragraph element with some text:"
      (repl-showme (html [:p "hello world"]))]
     [:li "Use a map to add a css class of " (c awesome) ":"
@@ -31,9 +31,11 @@
      (repl-showme (html [:head [:title "Mini-Browser"]] [:body {:id "browser"}]))]
     [:li "Ok, that is about enough HTML to view as a Clojure string. Let's make a server. Put the html from the previous step into a " (c mockup-1) " function:"
      (showme mockup-1)]
+    [:li "Use the " (c compojure.core) " namespace."]
     [:li "Use " (c defroutes) " to create a " (c mockup-routes) " table that routes a GET of /m1 to" (c mockup-1)". "
      (showme* '(defroutes mockup-routes
-                 (GET "/m1" (mockup-1))))]
+                 (GET "/m1" [] (mockup-1))))]
+    [:li "Use the " (c ring.adapter.jetty) " namespace."]
     [:li "Create a " (c mockup-server) " function that calls " (c run-server) " with three arguments:"
      [:ol
       [:li "a map with the port to use (8999)"]
@@ -44,7 +46,7 @@
     [:li "Let's create a more complete " (c mockup-2) " with some layout divs."
      (source mockup-2)]
     [:li "Add " (c mockup-2) " to a route /m2 and browse to " (ll "http://localhost:8999/m2") " to see the second mockup."]
-    [:li "Now let's add some standard styling and JavaScript. The " (c include-css) " function generates markup to pull in CSS files. Try it at the REPL:"
+    [:li "Now let's add some standard styling and JavaScript. The " (c include-css) " function from the " (c hiccup.page-helpers) " namespace generates markup to pull in CSS files. Try it at the REPL:"
      (repl-showme (include-css "/stylesheets/application.css"))]
     [:li (c include-js) " does the same thing for JavaScript:"
      (repl-showme (include-js "/javascripts/application.js"))]
@@ -52,12 +54,12 @@
      (repl-showme [default-stylesheets, default-javascripts])]
     [:li "Create a " (c mockup-3) " that adds the default CSS and JavaScripts:"
      (showme mockup-3)]
-    [:li "Add an m3 route to " (c mockup-3) ", and a catch-all route that serves files (The " (c serve-file) " function will serve files from the " (c public) " directory by default.)"
+    [:li "Add an m3 route to " (c mockup-3) ", and a catch-all route that serves files (The " (c files) " function will serve files from the " (c public) " directory by default.) You will need to use " (c compojure.route/files) "for the catch-all route."
      (showme* '(defroutes mockup-routes
-                 (GET "/m1" (mockup-1))
-                 (GET "/m2" (mockup-2))
-                 (GET "/m3" (mockup-3))
-                 (GET "/*" (or (serve-file (params :*)) :next))))]]])
+                 (GET "/m1" [] (mockup-1))
+                 (GET "/m2" [] (mockup-2))
+                 (GET "/m3" [] (mockup-3))
+                 (route/files "/")))]]])
 
 (defn static-mockup
   []
@@ -91,6 +93,7 @@
      (showme* '(defroutes browser-routes
                  (GET
                   "/"
+                  []
                   (html
                    (layout
                     (namespace-browser (namespace-names)))))))]

--- a/src/solutions/mini_browser.clj
+++ b/src/solutions/mini_browser.clj
@@ -95,8 +95,8 @@
      [:div {:class "browse-list empty"}])))
   (GET
    "/browse/*"
-   request
-   (let [[ns var] (str/split (get-in request [:params "*"]) #"/")]
+   {{path :*} :params}
+   (let [[ns var] (str/split path #"/")]
      (html
       (layout
        (namespace-browser (namespace-names))


### PR DESCRIPTION
In the current relevance/labrepl, `lein deps` is broken, due to a autodoc not being able to locate an old clojure-contrib SNAPSHOT. I started with a quick fix, but since autodoc doesn't actually appear to be used at all in the labrepl, I've removed that dependency in my fork.

I've also updated my fork to use the latest Compojure (0.5.1 => 0.6.3) and Hiccup (0.3.0 => 0.3.4), and also updated the mini-brower lab answer hints/answers to reflect those updates.

These changes cover all of the major issues in the 3 existing Pull Requests on relevance/labrepl, and also cover 6 of the 8 existing Github Issues.

Feel free to cherry-pick only the parts that Relevance would like to have - just wanted to push these updates back upstream to save someone else the headache.
- Colin
# 
# original pull request text:

It looks like autodoc 0.7.0, a labrepl dependency, was depending on an old clojure-contrib snapshot. This was breaking attempts to use `lein deps` in labrepl.

An easy fix here would be to specify :exclusions for the autodoc dev-dependency, as I've done in my fork, since it doesn't _really_ need that version. I've also submitted an issue to the autodoc project, but I'm not sure how easy it is to back-port changes to an old version (autodoc doesn't use tags).
# See also http://groups.google.com/group/clojure-dev/browse_thread/thread/149bc60e05cfaa2e.

Thanks,

Colin
