### PR TITLE
update dependency paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.jar
 bin/*
 classes/*
 lib/*

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,10 @@
   <name>labrepl</name>
   <description>Clojure exercises, with integrated repl and webapp</description>
   <scm>
-    <tag>94d648132b23a6f412dd3074ad60311dac5e458d</tag>
+    <connection>scm:git:git://github.com/relevance/labrepl.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/relevance/labrepl.git</developerConnection>
+    <tag>49efaab505b2670cff5e4ff8ded9160b3e47f272</tag>
+    <url>https://github.com/relevance/labrepl</url>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>
@@ -22,40 +25,19 @@
         <directory>test-resources</directory>
       </testResource>
     </testResources>
-    <plugins>
-      <plugin>
-        <groupId>com.theoryinpractise</groupId>
-        <artifactId>clojure-maven-plugin</artifactId>
-        <version>1.3.1</version>
-        <configuration>
-          <sourceDirectories>
-            <sourceDirectory>src</sourceDirectory>
-            <sourceDirectory>src/solutions</sourceDirectory>
-            <sourceDirectory>src/labrepl</sourceDirectory>
-            <sourceDirectory>src/labs</sourceDirectory>
-            <sourceDirectory>src/student</sourceDirectory>
-          </sourceDirectories>
-          <testSourceDirectories>
-            <testSourceDirectory>test</testSourceDirectory>
-            <testSourceDirectory>src/labrepl</testSourceDirectory>
-            <testSourceDirectory>test/solutions</testSourceDirectory>
-          </testSourceDirectories>
-        </configuration>
-      </plugin>
-    </plugins>
   </build>
   <repositories>
     <repository>
-      <id>central</id>
-      <url>http://repo1.maven.org/maven2</url>
-    </repository>
-    <repository>
-      <id>clojure</id>
+      <id>releases</id>
       <url>http://build.clojure.org/releases</url>
     </repository>
     <repository>
-      <id>clojure-snapshots</id>
+      <id>snapshots</id>
       <url>http://build.clojure.org/snapshots</url>
+    </repository>
+    <repository>
+      <id>central</id>
+      <url>http://repo1.maven.org/maven2</url>
     </repository>
     <repository>
       <id>clojars</id>
@@ -63,6 +45,18 @@
     </repository>
   </repositories>
   <dependencies>
+    <dependency>
+      <groupId>swank-clojure</groupId>
+      <artifactId>swank-clojure</artifactId>
+      <version>1.3.0-SNAPSHOT</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>clojure</artifactId>
+          <groupId>org.clojure</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
@@ -153,18 +147,6 @@
       <groupId>jline</groupId>
       <artifactId>jline</artifactId>
       <version>0.9.94</version>
-    </dependency>
-    <dependency>
-      <groupId>swank-clojure</groupId>
-      <artifactId>swank-clojure</artifactId>
-      <version>1.3.0-SNAPSHOT</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>clojure</artifactId>
-          <groupId>org.clojure</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
 </project>

--- a/project.clj
+++ b/project.clj
@@ -13,4 +13,6 @@
                                               com.sun.jmx/jmxri]]
                  [swank-clojure "1.3.0-SNAPSHOT" :exclusions [org.clojure/clojure]]
                  [jline "0.9.94"]]
-  :dev-dependencies [[swank-clojure "1.3.0-SNAPSHOT" :exclusions [org.clojure/clojure]]])
+  :dev-dependencies [[swank-clojure "1.3.0-SNAPSHOT" :exclusions [org.clojure/clojure]]]
+  :repositories {"snapshots" {:url "http://build.clojure.org/snapshots"}
+                 "releases" {:url "http://build.clojure.org/releases"}})


### PR DESCRIPTION
this fixes the following error that occurred on two machines when running `lein deps`:

```
... 11 more
Caused by: org.apache.maven.artifact.resolver.MultipleArtifactsNotFoundException: Missing:
----------
1) org.clojure:clojure:jar:1.3.0-master-SNAPSHOT

  Try downloading the file manually from the project website.

  Then, install it using the command:
      mvn install:install-file -DgroupId=org.clojure -DartifactId=clojure -Dversion=1.3.0-master-SNAPSHOT -Dpackaging=jar -Dfile=/path/to/file

  Alternatively, if you host your own repository you can deploy the file there:
      mvn deploy:deploy-file -DgroupId=org.clojure -DartifactId=clojure -Dversion=1.3.0-master-SNAPSHOT -Dpackaging=jar -Dfile=/path/to/file -Durl=[url] -DrepositoryId=[id]

  Path to dependency:
    1) org.apache.maven:super-pom:jar:2.0
    2) org.clojure:clojure:jar:1.3.0-master-SNAPSHOT

----------
1 required artifact is missing.

for artifact:
  org.apache.maven:super-pom:jar:2.0

from the specified remote repositories:
  clojars (http://clojars.org/repo/),
  central (http://repo1.maven.org/maven2)


  at org.apache.maven.artifact.resolver.DefaultArtifactResolver.resolveTransitively(DefaultArtifactResolver.java:324)
  at org.apache.maven.artifact.ant.DependenciesTask.doExecute(DependenciesTask.java:170)
  ... 33 more
```
