### PR TITLE
Fixes CLASSPATH issue and supports Lein 2

### DIFF
--- a/script/repl
+++ b/script/repl
@@ -1,8 +1,13 @@
 #!/bin/sh
-CLASSPATH=src:test:resources:data
+CLASSPATH=$CLASSPATH:src:test:resources:data
 
+# For lein 1
 for f in lib/*.jar; do
     CLASSPATH=$CLASSPATH:$f
 done
+
+# For lein 2
+CLASSPATH=$CLASSPATH:`lein classpath`
+
 
 java -Xmx1G -cp $CLASSPATH jline.ConsoleRunner clojure.main -i script/run.clj -r


### PR DESCRIPTION
This small fix is required to support both Lein 1 and Lein 2. On Lein 2, jar files are no longer copied to ./lib but the right classpath can be obtained with `lein classpath`
