### PR TITLE
Bring in REPL functions like `find-doc`, `source` and `javadoc`

### DIFF
--- a/src/labrepl.clj
+++ b/src/labrepl.clj
@@ -50,4 +50,5 @@
 
 (defn -main [& args]
   (run-jetty (var application) {:port 8080 :join? false})
+  (apply require clojure.main/repl-require)
   (println "Welcome to the labrepl. Browse to http://localhost:8080 to get started!"))


### PR DESCRIPTION
Required for the first 'intro' lab under Clojure 1.5

Disclaimer: my Clojure know-how is embryonic; perhaps this fix is better done a different way ...
